### PR TITLE
Allow running launchers directly.

### DIFF
--- a/coregrind/m_main.c
+++ b/coregrind/m_main.c
@@ -1401,9 +1401,8 @@ Int valgrind_main ( Int argc, HChar **argv, HChar **envp )
    VG_(debugLog)(1, "main", "Getting launcher's name ...\n");
    VG_(name_of_launcher) = VG_(getenv)(VALGRIND_LAUNCHER);
    if (VG_(name_of_launcher) == NULL) {
-      VG_(printf)("valgrind: You cannot run '%s' directly.\n", argv[0]);
+      VG_(printf)("valgrind: You should not run '%s' directly.\n", argv[0]);
       VG_(printf)("valgrind: You should use $prefix/bin/valgrind.\n");
-      VG_(exit)(1);
    }
    VG_(debugLog)(1, "main", "... %s\n", VG_(name_of_launcher));
 


### PR DESCRIPTION
Though it says that you shouldn't, I haven't seen any downsides to
doing so.  And being able to do so it very useful for debugging
valgrind with gdb.  So just make this a warning.