### PR TITLE
Add support for precise computation of SIMD greater-than.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1050,6 +1050,7 @@
 /memcheck/tests/amd64/insn-bsfl
 /memcheck/tests/amd64/insn-pmovmskb
 /memcheck/tests/amd64/insn-pcmpistri
+/memcheck/tests/amd64/pcmpgt
 /memcheck/tests/amd64/sh-mem-vec128
 /memcheck/tests/amd64/sh-mem-vec256
 /memcheck/tests/amd64/xsave-avx
@@ -1288,6 +1289,7 @@
 /memcheck/tests/x86/fxsave
 /memcheck/tests/x86/int3-x86
 /memcheck/tests/x86/more_x86_fp
+/memcheck/tests/x86/pcmpgt
 /memcheck/tests/x86/pushfpopf
 /memcheck/tests/x86/pushfw_x86
 /memcheck/tests/x86/pushpopmem

--- a/VEX/priv/host_amd64_isel.c
+++ b/VEX/priv/host_amd64_isel.c
@@ -3721,6 +3721,7 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, const IRExpr* e )
          return dst;
       }
 
+      case Iop_ShlN8x16: laneBits = 8;  op = Asse_SHL16; goto do_SseShift;
       case Iop_ShlN16x8: laneBits = 16; op = Asse_SHL16; goto do_SseShift;
       case Iop_ShlN32x4: laneBits = 32; op = Asse_SHL32; goto do_SseShift;
       case Iop_ShlN64x2: laneBits = 64; op = Asse_SHL64; goto do_SseShift;
@@ -3739,6 +3740,46 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, const IRExpr* e )
             vassert(c->tag == Ico_U8);
             UInt shift = c->Ico.U8;
             if (shift < laneBits) {
+               if (laneBits == 8) {
+                  /* This instruction doesn't exist so we need to fake it using
+                     Asse_SHL16 and Asse_SHR16.
+
+                     We'd like to shift every byte in the 16-byte register to
+                     the left by some amount.
+
+                     Instead, we will make a copy and shift all the 16-bit words
+                     to the *right* by 8 and then to the left by 8 plus the
+                     shift amount.  That will get use the correct answer for the
+                     upper 8 bits of each 16-bit word and zero elsewhere.
+
+                     Then we will shift all the 16-bit words in the original to
+                     the left by 8 plus the shift amount and then to the right
+                     by 8.  This will get the correct answer for the lower 8
+                     bits of each 16-bit word and zero elsewhere.
+
+                     Finally, we will OR those two results together.
+
+                     Because we don't have a shift by constant in x86, we store
+                     the constant 8 into a register and shift by that as needed.
+                  */
+                  AMD64SseOp reverse_op = op;
+                  switch (op) {
+                     case Asse_SHL16:
+                        reverse_op = Asse_SHR16;
+                        break;
+                     default:
+                        vpanic("Iop_ShlN8x16");
+                  }
+                  HReg hi  = newVRegV(env);
+                  addInstr(env, mk_vMOVsd_RR(greg, hi));
+                  addInstr(env, AMD64Instr_SseShiftN(reverse_op, 8, hi));
+                  addInstr(env, AMD64Instr_SseShiftN(op, 8+shift, hi));
+                  addInstr(env, mk_vMOVsd_RR(greg, dst));
+                  addInstr(env, AMD64Instr_SseShiftN(op, 8+shift, dst));
+                  addInstr(env, AMD64Instr_SseShiftN(reverse_op, 8, dst));
+                  addInstr(env, AMD64Instr_SseReRg(Asse_OR, hi, dst));
+                  return dst;
+               }
                addInstr(env, mk_vMOVsd_RR(greg, dst));
                addInstr(env, AMD64Instr_SseShiftN(op, shift, dst));
                return dst;
@@ -3751,6 +3792,30 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, const IRExpr* e )
          addInstr(env, AMD64Instr_Push(AMD64RMI_Imm(0)));
          addInstr(env, AMD64Instr_Push(rmi));
          addInstr(env, AMD64Instr_SseLdSt(True/*load*/, 16, ereg, rsp0));
+         if (laneBits == 8) {
+            /* This instruction doesn't exist so we need to fake it, in the same
+               way as above.
+            */
+            AMD64SseOp reverse_op = op;
+            switch (op) {
+               case Asse_SHL16:
+                  reverse_op = Asse_SHR16;
+                  break;
+               default:
+                  vpanic("Iop_ShlN8x16");
+            }
+            HReg hi  = newVRegV(env);
+            addInstr(env, mk_vMOVsd_RR(greg, hi));
+            addInstr(env, AMD64Instr_SseShiftN(reverse_op, 8, hi));
+            addInstr(env, AMD64Instr_SseShiftN(op, 8, hi));
+            addInstr(env, AMD64Instr_SseReRg(op, ereg, hi));
+            addInstr(env, mk_vMOVsd_RR(greg, dst));
+            addInstr(env, AMD64Instr_SseShiftN(op, 8, dst));
+            addInstr(env, AMD64Instr_SseReRg(op, ereg, dst));
+            addInstr(env, AMD64Instr_SseShiftN(reverse_op, 8, dst));
+            addInstr(env, AMD64Instr_SseReRg(Asse_OR, hi, dst));
+            return dst;
+         }
          addInstr(env, mk_vMOVsd_RR(greg, dst));
          addInstr(env, AMD64Instr_SseReRg(op, ereg, dst));
          add_to_rsp(env, 16);

--- a/VEX/priv/host_x86_isel.c
+++ b/VEX/priv/host_x86_isel.c
@@ -3771,6 +3771,62 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, const IRExpr* e )
          return dst;
       }
 
+      case Iop_ShlN8x16: {
+         /* This instruction doesn't exist so we need to fake it using
+            Xsse_SHL16 and Xsse_SHR16.
+
+            We'd like to shift every byte in the 16-byte register to the left by
+            some amount.
+
+            Instead, we will make a copy and shift all the 16-bit words to the
+            *right* by 8 and then to the left by 8 plus the shift amount.  That
+            will get use the correct answer for the upper 8 bits of each 16-bit
+            word and zero elsewhere.
+
+            Then we will shift all the 16-bit words in the original to the left
+            by 8 plus the shift amount and then to the right by 8.  This will
+            get the correct answer for the lower 8 bits of each 16-bit word and
+            zero elsewhere.
+
+            Finally, we will OR those two results together.
+
+            Because we don't have a shift by constant in x86, we store the
+            constant 8 into a register and shift by that as needed.
+         */
+         HReg      greg  = iselVecExpr(env, e->Iex.Binop.arg1);
+         X86RMI*   rmi   = iselIntExpr_RMI(env, e->Iex.Binop.arg2);
+         X86AMode* esp0  = X86AMode_IR(0, hregX86_ESP());
+         HReg      ereg  = newVRegV(env);
+         HReg      eight = newVRegV(env); // To store the constant value 8.
+         HReg      dst   = newVRegV(env);
+         HReg      hi    = newVRegV(env);
+         REQUIRE_SSE2;
+         addInstr(env, X86Instr_Push(X86RMI_Imm(0)));
+         addInstr(env, X86Instr_Push(X86RMI_Imm(0)));
+         addInstr(env, X86Instr_Push(X86RMI_Imm(0)));
+         addInstr(env, X86Instr_Push(rmi));
+         addInstr(env, X86Instr_SseLdSt(True/*load*/, ereg, esp0));
+         addInstr(env, X86Instr_Push(X86RMI_Imm(0)));
+         addInstr(env, X86Instr_Push(X86RMI_Imm(0)));
+         addInstr(env, X86Instr_Push(X86RMI_Imm(0)));
+         addInstr(env, X86Instr_Push(X86RMI_Imm(8)));
+         addInstr(env, X86Instr_SseLdSt(True/*load*/, eight, esp0));
+
+         op = Xsse_SHL16;
+         X86SseOp reverse_op = Xsse_SHR16;
+         addInstr(env, mk_vMOVsd_RR(greg, hi));
+         addInstr(env, X86Instr_SseReRg(reverse_op, eight, hi));
+         addInstr(env, X86Instr_SseReRg(op, eight, hi));
+         addInstr(env, X86Instr_SseReRg(op, ereg, hi));
+         addInstr(env, mk_vMOVsd_RR(greg, dst));
+         addInstr(env, X86Instr_SseReRg(op, eight, dst));
+         addInstr(env, X86Instr_SseReRg(op, ereg, dst));
+         addInstr(env, X86Instr_SseReRg(reverse_op, eight, dst));
+         addInstr(env, X86Instr_SseReRg(Xsse_OR, hi, dst));
+
+         add_to_esp(env, 32);
+         return dst;
+      }
       case Iop_ShlN16x8: op = Xsse_SHL16; goto do_SseShift;
       case Iop_ShlN32x4: op = Xsse_SHL32; goto do_SseShift;
       case Iop_ShlN64x2: op = Xsse_SHL64; goto do_SseShift;

--- a/memcheck/tests/amd64/Makefile.am
+++ b/memcheck/tests/amd64/Makefile.am
@@ -19,6 +19,7 @@ EXTRA_DIST = \
 	insn-pmovmskb.vgtest insn-pmovmskb.stdout.exp insn-pmovmskb.stderr.exp \
 		insn-pmovmskb.stderr.exp-clang \
 	more_x87_fp.stderr.exp more_x87_fp.stdout.exp more_x87_fp.vgtest \
+	pcmpgt.stderr.exp pcmpgt.vgtest \
 	sh-mem-vec128-plo-no.vgtest \
 		sh-mem-vec128-plo-no.stderr.exp \
 		sh-mem-vec128-plo-no.stdout.exp \
@@ -44,6 +45,7 @@ check_PROGRAMS = \
 	fxsave-amd64 \
 	insn-bsfl \
 	insn-pmovmskb \
+	pcmpgt \
 	sh-mem-vec128 \
 	sse_memory \
 	xor-undef-amd64
@@ -76,4 +78,5 @@ insn_pcmpistri_CFLAGS	= $(AM_CFLAGS)
 more_x87_fp_CFLAGS	= $(AM_CFLAGS) -O -ffast-math -mfpmath=387 \
 				-mfancy-math-387
 more_x87_fp_LDADD	= -lm
+pcmpgt_SOURCES = pcmpgt.cpp
 shr_edx_CFLAGS		= $(AM_CFLAGS) @FLAG_NO_PIE@ @FLAG_W_NO_UNINITIALIZED@

--- a/memcheck/tests/amd64/pcmpgt.cpp
+++ b/memcheck/tests/amd64/pcmpgt.cpp
@@ -1,0 +1,1 @@
+../common/pcmpgt.cpp

--- a/memcheck/tests/amd64/pcmpgt.stderr.exp
+++ b/memcheck/tests/amd64/pcmpgt.stderr.exp
@@ -1,0 +1,1604 @@
+
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:227)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:227)
+
+xxxxxxxxxxxxxxxx > xxxxxxxxxxxxxxxx, completely undefined, error above, 1 == 1
+0000000000000000 > 0000000000000000, completely defined, 0 == 0
+0000000000000000 > f000000000000000, completely defined, 0 == 0
+f000000000000000 > 0000000000000000, completely defined, 0 == 0
+0000000000000000 > fxxxxxxxxxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxxxxxxxxxx > fxxxxxxxxxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:233)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:233)
+
+xxxxxxxxxxxxxxx0 > f000000000000000, undefined, error above, 1 == 1
+xxxxxxxxxxxxxxx1 > 8000000000000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxxxxxxxxxx > 6xxxxxxxxxxxxxxx, defined, 0 == 0
+8xxxxxxxxxxxxxxx > 9xxxxxxxxxxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:237)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:237)
+
+123456781234567x > 1234567812345678, undefined, error above, 1 == 1
+123456781234567x > 123456781234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:239)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned long, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:239)
+
+123456781234567x > 123456781234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:241)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:241)
+
+xxxxxxxxxxxxxxxx > xxxxxxxxxxxxxxxx, completely undefined, error above, 1 == 1
+0000000000000000 > 0000000000000000, completely defined, 0 == 0
+0000000000000000 > f000000000000000, completely defined, 0 == 0
+f000000000000000 > 0000000000000000, completely defined, 0 == 0
+0000000000000000 > fxxxxxxxxxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxxxxxxxxxx > fxxxxxxxxxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:247)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:247)
+
+xxxxxxxxxxxxxxx0 > f000000000000000, undefined, error above, 1 == 1
+xxxxxxxxxxxxxxx1 > 8000000000000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxxxxxxxxxx > 6xxxxxxxxxxxxxxx, defined, 0 == 0
+8xxxxxxxxxxxxxxx > 9xxxxxxxxxxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:251)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:251)
+
+123456781234567x > 1234567812345678, undefined, error above, 1 == 1
+123456781234567x > 123456781234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:253)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned long, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:253)
+
+123456781234567x > 123456781234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:255)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:255)
+
+xxxxxxxx > xxxxxxxx, completely undefined, error above, 1 == 1
+00000000 > 00000000, completely defined, 0 == 0
+00000000 > f0000000, completely defined, 0 == 0
+f0000000 > 00000000, completely defined, 0 == 0
+00000000 > fxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxx > fxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:261)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:261)
+
+xxxxxxx0 > f0000000, undefined, error above, 1 == 1
+xxxxxxx1 > 80000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxx > 6xxxxxxx, defined, 0 == 0
+8xxxxxxx > 9xxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:265)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:265)
+
+1234567x > 12345678, undefined, error above, 1 == 1
+1234567x > 1234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:267)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:267)
+
+1234567x > 1234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:269)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:269)
+
+xxxxxxxx > xxxxxxxx, completely undefined, error above, 1 == 1
+00000000 > 00000000, completely defined, 0 == 0
+00000000 > f0000000, completely defined, 0 == 0
+f0000000 > 00000000, completely defined, 0 == 0
+00000000 > fxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxx > fxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:275)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:275)
+
+xxxxxxx0 > f0000000, undefined, error above, 1 == 1
+xxxxxxx1 > 80000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxx > 6xxxxxxx, defined, 0 == 0
+8xxxxxxx > 9xxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:279)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:279)
+
+1234567x > 12345678, undefined, error above, 1 == 1
+1234567x > 1234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:281)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:281)
+
+1234567x > 1234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:283)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:283)
+
+xxxxxxxx > xxxxxxxx, completely undefined, error above, 1 == 1
+00000000 > 00000000, completely defined, 0 == 0
+00000000 > f0000000, completely defined, 0 == 0
+f0000000 > 00000000, completely defined, 0 == 0
+00000000 > fxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxx > fxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:289)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:289)
+
+xxxxxxx0 > f0000000, undefined, error above, 1 == 1
+xxxxxxx1 > 80000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxx > 6xxxxxxx, defined, 0 == 0
+8xxxxxxx > 9xxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:293)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:293)
+
+1234567x > 12345678, undefined, error above, 1 == 1
+1234567x > 1234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:295)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:295)
+
+1234567x > 1234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:297)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:297)
+
+xxxxxxxx > xxxxxxxx, completely undefined, error above, 1 == 1
+00000000 > 00000000, completely defined, 0 == 0
+00000000 > f0000000, completely defined, 0 == 0
+f0000000 > 00000000, completely defined, 0 == 0
+00000000 > fxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxx > fxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:303)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:303)
+
+xxxxxxx0 > f0000000, undefined, error above, 1 == 1
+xxxxxxx1 > 80000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxx > 6xxxxxxx, defined, 0 == 0
+8xxxxxxx > 9xxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:307)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:307)
+
+1234567x > 12345678, undefined, error above, 1 == 1
+1234567x > 1234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:309)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:309)
+
+1234567x > 1234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:311)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:311)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:317)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:317)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:321)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:321)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:323)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:323)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:325)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:325)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:331)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:331)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:335)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:335)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:337)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:337)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:339)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:339)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:345)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:345)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:349)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:349)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:351)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:351)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:353)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:353)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:359)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:359)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:363)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:363)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:365)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:365)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:367)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:367)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:373)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:373)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:377)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:377)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:379)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:379)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:381)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:381)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:387)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:387)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:391)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:391)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:393)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:393)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:395)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:395)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:401)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:401)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+
+More than 100 errors detected.  Subsequent errors
+will still be recorded, but in less detail than before.
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:405)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:405)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:407)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:407)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:409)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:409)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:415)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:415)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:419)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:419)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:421)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:421)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:423)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:423)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:429)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:429)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:433)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:433)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:435)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:435)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:437)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:437)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:443)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:443)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:447)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:447)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:449)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:449)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:451)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:451)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:457)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:457)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:461)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:461)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:463)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:463)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:465)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:465)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:471)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:471)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:475)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:475)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:477)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:477)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:479)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:479)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:485)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:485)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:489)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:489)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:491)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:491)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:493)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:493)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:499)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:499)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:503)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:503)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:505)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:505)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:507)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:507)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:513)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:513)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:517)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:517)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:519)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:519)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:521)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:521)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:527)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:527)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:531)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:531)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:533)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:533)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:535)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:535)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:541)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:541)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:545)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:545)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:547)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:547)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:549)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:549)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:555)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:555)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:559)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:559)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:561)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:561)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:563)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:563)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:569)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:569)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:573)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:573)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:575)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:575)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:577)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:577)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:583)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:583)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:587)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:587)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:589)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:589)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:591)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:591)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:597)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:597)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:601)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:601)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:603)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:603)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:605)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:605)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:611)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:611)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:615)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:615)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:617)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:617)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:619)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:619)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:625)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:625)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:629)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:629)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:631)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:631)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:633)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:633)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:639)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:639)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:643)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:643)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:201)
+   by 0x........: main (pcmpgt.cpp:645)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:197)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:206)
+   by 0x........: main (pcmpgt.cpp:645)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+
+HEAP SUMMARY:
+    in use at exit: ... bytes in ... blocks
+  total heap usage: ... allocs, ... frees, ... bytes allocated
+
+For a detailed leak analysis, rerun with: --leak-check=full
+
+Use --track-origins=yes to see where uninitialised values come from
+For lists of detected and suppressed errors, rerun with: -s
+ERROR SUMMARY: 240 errors from 240 contexts (suppressed: 0 from 0)

--- a/memcheck/tests/amd64/pcmpgt.vgtest
+++ b/memcheck/tests/amd64/pcmpgt.vgtest
@@ -1,0 +1,3 @@
+prog: pcmpgt amd64
+prereq: test -e pcmpgt
+stderr_filter: ../filter_allocs

--- a/memcheck/tests/common/Makefile.am
+++ b/memcheck/tests/common/Makefile.am
@@ -2,6 +2,7 @@
 include $(top_srcdir)/Makefile.tool-tests.am
 
 EXTRA_DIST = \
+	pcmpgt.cpp \
 	sh-mem-vec128.tmpl.c \
 	sh-mem-vec128-plo-no.stderr.exp-32bit-le \
 	sh-mem-vec128-plo-yes.stderr.exp-32bit-le \

--- a/memcheck/tests/common/pcmpgt.cpp
+++ b/memcheck/tests/common/pcmpgt.cpp
@@ -1,0 +1,649 @@
+/* https://bugs.kde.org/show_bug.cgi?id=432801 */
+
+#include <signal.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+#include <ctype.h>
+#include <immintrin.h>
+
+#include "../../memcheck.h"
+
+// This function fails when compiled on clang version 10 or greater with -O2.
+// It's unused by the test but left here as a copy of the error in the bug
+// report https://bugs.kde.org/show_bug.cgi?id=432801
+void standalone() {
+   struct sigaction act;
+   if (sigaction(SIGTERM, 0, &act) == 1) {
+      return;
+   }
+   if (sigaction(SIGTERM, 0, &act) == 1) {
+      return;
+   }
+
+   char pattern[] = "\x1\x2\x3\x4\x5\x6\x7\x8\x9";
+   const unsigned long plen = strlen(pattern);
+   pattern[1] = 0;
+   size_t hp=0;
+   for (size_t i = 0; i < plen; ++i)
+      hp += pattern[i];
+   volatile size_t j = 0;
+   if (j == hp % 10) {
+      j++;
+   }
+   printf("%zd\n", hp);
+}
+
+typedef union V128 {
+  struct {
+    uint64_t w64[2];  /* Note: little-endian */
+  };
+  struct {
+   uint32_t w32[4];  /* Note: little-endian */
+  };
+  struct {
+    uint16_t w16[8];  /* Note: little-endian */
+  };
+  struct {
+   uint8_t w8[16];  /* Note: little-endian */
+  };
+} V128;
+
+template <typename T>
+static T cmpGT(V128 x, V128 y, size_t element_select) = delete;
+
+template <>
+uint64_t cmpGT(V128 x, V128 y, size_t element_select) {
+  uint8_t x_data[16];
+  uint8_t y_data[16];
+  memcpy(x_data, &x, sizeof(V128));
+  memcpy(y_data, &y, sizeof(V128));
+  __asm__ __volatile__(
+      "movdqu     (%1), %%xmm5 \n"
+      "movdqu     (%0), %%xmm6 \n"
+      // order swapped for AT&T style which has destination second.
+      "pcmpgtq %%xmm5,%%xmm6 \n"
+      "movdqu   %%xmm6, (%0) \n"
+      :
+      : "r"(x_data), "r"(y_data)
+      : "memory", "xmm5", "xmm6" /* clobbers */);
+  memcpy(&x, x_data, sizeof(V128));
+
+  return ((uint64_t*)&x)[element_select];
+}
+
+template <>
+uint32_t cmpGT(V128 x, V128 y, size_t element_select) {
+  uint8_t x_data[16];
+  uint8_t y_data[16];
+  memcpy(x_data, &x, sizeof(V128));
+  memcpy(y_data, &y, sizeof(V128));
+  __asm__ __volatile__(
+      "movdqu     (%1), %%xmm5 \n"
+      "movdqu     (%0), %%xmm6 \n"
+      // order swapped for AT&T style which has destination second.
+      "pcmpgtd %%xmm5,%%xmm6 \n"
+      "movdqu   %%xmm6, (%0) \n"
+      :
+      : "r"(x_data), "r"(y_data)
+      : "memory", "xmm5", "xmm6" /* clobbers */);
+  memcpy(&x, x_data, sizeof(V128));
+
+  return ((uint32_t*)&x)[element_select];
+}
+
+template <>
+uint16_t cmpGT(V128 x, V128 y, size_t element_select) {
+  uint8_t x_data[16];
+  uint8_t y_data[16];
+  memcpy(x_data, &x, sizeof(V128));
+  memcpy(y_data, &y, sizeof(V128));
+  __asm__ __volatile__(
+      "movdqu     (%1), %%xmm5 \n"
+      "movdqu     (%0), %%xmm6 \n"
+      // order swapped for AT&T style which has destination second.
+      "pcmpgtw %%xmm5,%%xmm6 \n"
+      "movdqu   %%xmm6, (%0) \n"
+      :
+      : "r"(x_data), "r"(y_data)
+      : "memory", "xmm5", "xmm6" /* clobbers */);
+  memcpy(&x, x_data, sizeof(V128));
+
+  return ((uint16_t*)&x)[element_select];
+}
+
+template <>
+uint8_t cmpGT(V128 x, V128 y, size_t element_select) {
+  uint8_t x_data[16];
+  uint8_t y_data[16];
+  memcpy(x_data, &x, sizeof(V128));
+  memcpy(y_data, &y, sizeof(V128));
+  __asm__ __volatile__(
+      "movdqu     (%1), %%xmm5 \n"
+      "movdqu     (%0), %%xmm6 \n"
+      // order swapped for AT&T style which has destination second.
+      "pcmpgtb %%xmm5,%%xmm6 \n"
+      "movdqu   %%xmm6, (%0) \n"
+      :
+      : "r"(x_data), "r"(y_data)
+      : "memory", "xmm5", "xmm6" /* clobbers */);
+  memcpy(&x, x_data, sizeof(V128));
+
+  return ((uint8_t*)&x)[element_select];
+}
+
+static void set_vbits(V128 *addr, V128 vbits)
+{
+   for (size_t i=0 ; i<2 ; ++i) {
+      (void)VALGRIND_SET_VBITS(&addr->w64[i], &vbits.w64[i], sizeof(vbits.w64[i]));
+   }
+}
+
+// Convert a string like "123XXX45" to a value and vbits.
+template <typename T>
+static void string_to_vbits(const char *s, T *x, T *vx)
+{
+   *x = 0;
+   *vx = 0;
+
+   for (; *s; s++) {
+      int lowered_c = tolower(*s);
+      *x <<= 4;
+      *vx <<= 4;
+      if (lowered_c == 'x') {
+         *vx |= 0xf;
+      } else if (isdigit(lowered_c)) {
+         *x |= lowered_c - '0';
+      } else if (lowered_c >= 'a' && lowered_c <= 'f') {
+         *x |= lowered_c - 'a' + 0xa;
+      } else {
+         fprintf(stderr, "Not a hex digit: %c\n", *s);
+         exit(1);
+      }
+   }
+}
+
+template <typename T>
+static V128 string_to_vbits(const char *s, size_t lane) {
+   T x, vx;
+   string_to_vbits(s, &x, &vx);
+
+   V128 vx128 = {{0}};
+   vx128.w32[0] = 0xffffffff;
+   vx128.w32[1] = 0xffffffff;
+   vx128.w32[2] = 0xffffffff;
+   vx128.w32[3] = 0xffffffff;
+   V128 x128 = {{0}};
+   if (sizeof(T) == 8) {
+     vx128.w64[lane] = vx;
+     x128.w64[lane] = x;
+   } else if (sizeof(T) == 4) {
+     vx128.w32[lane] = vx;
+     x128.w32[lane] = x;
+   } else if (sizeof(T) == 2) {
+     vx128.w16[lane] = vx;
+     x128.w16[lane] = x;
+   } else {
+     vx128.w8[lane] = vx;
+     x128.w8[lane] = x;
+   }
+   set_vbits(&x128, vx128);
+   return x128;
+}
+
+template <typename T, int lane>
+static void doit(const char *x, const char *y, bool expected_undefined, const char *err_msg) {
+  int result = cmpGT<T>(string_to_vbits<T>(x, lane),
+                        string_to_vbits<T>(y, lane),
+                        lane);
+  int undefined = VALGRIND_CHECK_VALUE_IS_DEFINED(result);
+  if (!!undefined != expected_undefined) {
+    fprintf(stderr, "ERROR: ");
+  }
+  // Force the result to be used.
+  if (result) {
+    fflush(stderr);
+  }
+  fprintf(stderr, "%s > %s, %s, %d == %d\n", x, y, err_msg, !!undefined, !!expected_undefined);
+}
+
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    fprintf(stderr, "First and only argument ought to be \"amd64\" or \"x86\"\n");
+    exit(1);
+  }
+  bool amd64;
+  if (strcmp(argv[1], "amd64") == 0) {
+    amd64 = true;
+  } else if (strcmp(argv[1], "x86") == 0) {
+    amd64 = false;
+  } else {
+    fprintf(stderr, "First and only argument ought to be \"amd64\" or \"x86\"\n");
+    exit(1);
+  }
+  if (amd64) {
+    doit<uint64_t, 0>("xxxxxxxxxxxxxxxx", "xxxxxxxxxxxxxxxx", true, "completely undefined, error above");
+    doit<uint64_t, 0>("0000000000000000", "0000000000000000", false, "completely defined");
+    doit<uint64_t, 0>("0000000000000000", "f000000000000000", false, "completely defined");
+    doit<uint64_t, 0>("f000000000000000", "0000000000000000", false, "completely defined");
+    doit<uint64_t, 0>("0000000000000000", "fxxxxxxxxxxxxxxx", false, "defined: 0 > all negatives");
+    doit<uint64_t, 0>("0xxxxxxxxxxxxxxx", "fxxxxxxxxxxxxxxx", false, "defined: non-negatives > all negatives");
+    doit<uint64_t, 0>("xxxxxxxxxxxxxxx0", "f000000000000000", true, "undefined, error above");
+    doit<uint64_t, 0>("xxxxxxxxxxxxxxx1", "8000000000000000", false, "defined: ends with 1 > MIN_INT");
+    doit<uint64_t, 0>("5xxxxxxxxxxxxxxx", "6xxxxxxxxxxxxxxx", false, "defined");
+    doit<uint64_t, 0>("8xxxxxxxxxxxxxxx", "9xxxxxxxxxxxxxxx", false, "defined");
+    doit<uint64_t, 0>("123456781234567x", "1234567812345678", true, "undefined, error above");
+    doit<uint64_t, 0>("123456781234567x", "123456781234567f", false, "defined: x can't be more than f");
+    doit<uint64_t, 0>("123456781234567x", "123456781234567e", true, "undefined: x can be more than e, error above");
+
+    doit<uint64_t, 1>("xxxxxxxxxxxxxxxx", "xxxxxxxxxxxxxxxx", true, "completely undefined, error above");
+    doit<uint64_t, 1>("0000000000000000", "0000000000000000", false, "completely defined");
+    doit<uint64_t, 1>("0000000000000000", "f000000000000000", false, "completely defined");
+    doit<uint64_t, 1>("f000000000000000", "0000000000000000", false, "completely defined");
+    doit<uint64_t, 1>("0000000000000000", "fxxxxxxxxxxxxxxx", false, "defined: 0 > all negatives");
+    doit<uint64_t, 1>("0xxxxxxxxxxxxxxx", "fxxxxxxxxxxxxxxx", false, "defined: non-negatives > all negatives");
+    doit<uint64_t, 1>("xxxxxxxxxxxxxxx0", "f000000000000000", true, "undefined, error above");
+    doit<uint64_t, 1>("xxxxxxxxxxxxxxx1", "8000000000000000", false, "defined: ends with 1 > MIN_INT");
+    doit<uint64_t, 1>("5xxxxxxxxxxxxxxx", "6xxxxxxxxxxxxxxx", false, "defined");
+    doit<uint64_t, 1>("8xxxxxxxxxxxxxxx", "9xxxxxxxxxxxxxxx", false, "defined");
+    doit<uint64_t, 1>("123456781234567x", "1234567812345678", true, "undefined, error above");
+    doit<uint64_t, 1>("123456781234567x", "123456781234567f", false, "defined: x can't be more than f");
+    doit<uint64_t, 1>("123456781234567x", "123456781234567e", true, "undefined: x can be more than e, error above");
+  }
+  doit<uint32_t, 0>("xxxxxxxx", "xxxxxxxx", true, "completely undefined, error above");
+  doit<uint32_t, 0>("00000000", "00000000", false, "completely defined");
+  doit<uint32_t, 0>("00000000", "f0000000", false, "completely defined");
+  doit<uint32_t, 0>("f0000000", "00000000", false, "completely defined");
+  doit<uint32_t, 0>("00000000", "fxxxxxxx", false, "defined: 0 > all negatives");
+  doit<uint32_t, 0>("0xxxxxxx", "fxxxxxxx", false, "defined: non-negatives > all negatives");
+  doit<uint32_t, 0>("xxxxxxx0", "f0000000", true, "undefined, error above");
+  doit<uint32_t, 0>("xxxxxxx1", "80000000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint32_t, 0>("5xxxxxxx", "6xxxxxxx", false, "defined");
+  doit<uint32_t, 0>("8xxxxxxx", "9xxxxxxx", false, "defined");
+  doit<uint32_t, 0>("1234567x", "12345678", true, "undefined, error above");
+  doit<uint32_t, 0>("1234567x", "1234567f", false, "defined: x can't be more than f");
+  doit<uint32_t, 0>("1234567x", "1234567e", true, "undefined: x can be more than e, error above");
+
+  doit<uint32_t, 1>("xxxxxxxx", "xxxxxxxx", true, "completely undefined, error above");
+  doit<uint32_t, 1>("00000000", "00000000", false, "completely defined");
+  doit<uint32_t, 1>("00000000", "f0000000", false, "completely defined");
+  doit<uint32_t, 1>("f0000000", "00000000", false, "completely defined");
+  doit<uint32_t, 1>("00000000", "fxxxxxxx", false, "defined: 0 > all negatives");
+  doit<uint32_t, 1>("0xxxxxxx", "fxxxxxxx", false, "defined: non-negatives > all negatives");
+  doit<uint32_t, 1>("xxxxxxx0", "f0000000", true, "undefined, error above");
+  doit<uint32_t, 1>("xxxxxxx1", "80000000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint32_t, 1>("5xxxxxxx", "6xxxxxxx", false, "defined");
+  doit<uint32_t, 1>("8xxxxxxx", "9xxxxxxx", false, "defined");
+  doit<uint32_t, 1>("1234567x", "12345678", true, "undefined, error above");
+  doit<uint32_t, 1>("1234567x", "1234567f", false, "defined: x can't be more than f");
+  doit<uint32_t, 1>("1234567x", "1234567e", true, "undefined: x can be more than e, error above");
+
+  doit<uint32_t, 2>("xxxxxxxx", "xxxxxxxx", true, "completely undefined, error above");
+  doit<uint32_t, 2>("00000000", "00000000", false, "completely defined");
+  doit<uint32_t, 2>("00000000", "f0000000", false, "completely defined");
+  doit<uint32_t, 2>("f0000000", "00000000", false, "completely defined");
+  doit<uint32_t, 2>("00000000", "fxxxxxxx", false, "defined: 0 > all negatives");
+  doit<uint32_t, 2>("0xxxxxxx", "fxxxxxxx", false, "defined: non-negatives > all negatives");
+  doit<uint32_t, 2>("xxxxxxx0", "f0000000", true, "undefined, error above");
+  doit<uint32_t, 2>("xxxxxxx1", "80000000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint32_t, 2>("5xxxxxxx", "6xxxxxxx", false, "defined");
+  doit<uint32_t, 2>("8xxxxxxx", "9xxxxxxx", false, "defined");
+  doit<uint32_t, 2>("1234567x", "12345678", true, "undefined, error above");
+  doit<uint32_t, 2>("1234567x", "1234567f", false, "defined: x can't be more than f");
+  doit<uint32_t, 2>("1234567x", "1234567e", true, "undefined: x can be more than e, error above");
+
+  doit<uint32_t, 3>("xxxxxxxx", "xxxxxxxx", true, "completely undefined, error above");
+  doit<uint32_t, 3>("00000000", "00000000", false, "completely defined");
+  doit<uint32_t, 3>("00000000", "f0000000", false, "completely defined");
+  doit<uint32_t, 3>("f0000000", "00000000", false, "completely defined");
+  doit<uint32_t, 3>("00000000", "fxxxxxxx", false, "defined: 0 > all negatives");
+  doit<uint32_t, 3>("0xxxxxxx", "fxxxxxxx", false, "defined: non-negatives > all negatives");
+  doit<uint32_t, 3>("xxxxxxx0", "f0000000", true, "undefined, error above");
+  doit<uint32_t, 3>("xxxxxxx1", "80000000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint32_t, 3>("5xxxxxxx", "6xxxxxxx", false, "defined");
+  doit<uint32_t, 3>("8xxxxxxx", "9xxxxxxx", false, "defined");
+  doit<uint32_t, 3>("1234567x", "12345678", true, "undefined, error above");
+  doit<uint32_t, 3>("1234567x", "1234567f", false, "defined: x can't be more than f");
+  doit<uint32_t, 3>("1234567x", "1234567e", true, "undefined: x can be more than e, error above");
+
+  doit<uint16_t, 0>("xxxx", "xxxx", true, "completely undefined, error above");
+  doit<uint16_t, 0>("0000", "0000", false, "completely defined");
+  doit<uint16_t, 0>("0000", "f000", false, "completely defined");
+  doit<uint16_t, 0>("f000", "0000", false, "completely defined");
+  doit<uint16_t, 0>("0000", "fxxx", false, "defined: 0 > all negatives");
+  doit<uint16_t, 0>("0xxx", "fxxx", false, "defined: non-negatives > all negatives");
+  doit<uint16_t, 0>("xxx0", "f000", true, "undefined, error above");
+  doit<uint16_t, 0>("xxx1", "8000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint16_t, 0>("5xxx", "6xxx", false, "defined");
+  doit<uint16_t, 0>("8xxx", "9xxx", false, "defined");
+  doit<uint16_t, 0>("123x", "1234", true, "undefined, error above");
+  doit<uint16_t, 0>("123x", "123f", false, "defined: x can't be more than f");
+  doit<uint16_t, 0>("123x", "123e", true, "undefined: x can be more than e, error above");
+
+  doit<uint16_t, 1>("xxxx", "xxxx", true, "completely undefined, error above");
+  doit<uint16_t, 1>("0000", "0000", false, "completely defined");
+  doit<uint16_t, 1>("0000", "f000", false, "completely defined");
+  doit<uint16_t, 1>("f000", "0000", false, "completely defined");
+  doit<uint16_t, 1>("0000", "fxxx", false, "defined: 0 > all negatives");
+  doit<uint16_t, 1>("0xxx", "fxxx", false, "defined: non-negatives > all negatives");
+  doit<uint16_t, 1>("xxx0", "f000", true, "undefined, error above");
+  doit<uint16_t, 1>("xxx1", "8000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint16_t, 1>("5xxx", "6xxx", false, "defined");
+  doit<uint16_t, 1>("8xxx", "9xxx", false, "defined");
+  doit<uint16_t, 1>("123x", "1234", true, "undefined, error above");
+  doit<uint16_t, 1>("123x", "123f", false, "defined: x can't be more than f");
+  doit<uint16_t, 1>("123x", "123e", true, "undefined: x can be more than e, error above");
+
+  doit<uint16_t, 2>("xxxx", "xxxx", true, "completely undefined, error above");
+  doit<uint16_t, 2>("0000", "0000", false, "completely defined");
+  doit<uint16_t, 2>("0000", "f000", false, "completely defined");
+  doit<uint16_t, 2>("f000", "0000", false, "completely defined");
+  doit<uint16_t, 2>("0000", "fxxx", false, "defined: 0 > all negatives");
+  doit<uint16_t, 2>("0xxx", "fxxx", false, "defined: non-negatives > all negatives");
+  doit<uint16_t, 2>("xxx0", "f000", true, "undefined, error above");
+  doit<uint16_t, 2>("xxx1", "8000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint16_t, 2>("5xxx", "6xxx", false, "defined");
+  doit<uint16_t, 2>("8xxx", "9xxx", false, "defined");
+  doit<uint16_t, 2>("123x", "1234", true, "undefined, error above");
+  doit<uint16_t, 2>("123x", "123f", false, "defined: x can't be more than f");
+  doit<uint16_t, 2>("123x", "123e", true, "undefined: x can be more than e, error above");
+
+  doit<uint16_t, 3>("xxxx", "xxxx", true, "completely undefined, error above");
+  doit<uint16_t, 3>("0000", "0000", false, "completely defined");
+  doit<uint16_t, 3>("0000", "f000", false, "completely defined");
+  doit<uint16_t, 3>("f000", "0000", false, "completely defined");
+  doit<uint16_t, 3>("0000", "fxxx", false, "defined: 0 > all negatives");
+  doit<uint16_t, 3>("0xxx", "fxxx", false, "defined: non-negatives > all negatives");
+  doit<uint16_t, 3>("xxx0", "f000", true, "undefined, error above");
+  doit<uint16_t, 3>("xxx1", "8000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint16_t, 3>("5xxx", "6xxx", false, "defined");
+  doit<uint16_t, 3>("8xxx", "9xxx", false, "defined");
+  doit<uint16_t, 3>("123x", "1234", true, "undefined, error above");
+  doit<uint16_t, 3>("123x", "123f", false, "defined: x can't be more than f");
+  doit<uint16_t, 3>("123x", "123e", true, "undefined: x can be more than e, error above");
+
+  doit<uint16_t, 4>("xxxx", "xxxx", true, "completely undefined, error above");
+  doit<uint16_t, 4>("0000", "0000", false, "completely defined");
+  doit<uint16_t, 4>("0000", "f000", false, "completely defined");
+  doit<uint16_t, 4>("f000", "0000", false, "completely defined");
+  doit<uint16_t, 4>("0000", "fxxx", false, "defined: 0 > all negatives");
+  doit<uint16_t, 4>("0xxx", "fxxx", false, "defined: non-negatives > all negatives");
+  doit<uint16_t, 4>("xxx0", "f000", true, "undefined, error above");
+  doit<uint16_t, 4>("xxx1", "8000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint16_t, 4>("5xxx", "6xxx", false, "defined");
+  doit<uint16_t, 4>("8xxx", "9xxx", false, "defined");
+  doit<uint16_t, 4>("123x", "1234", true, "undefined, error above");
+  doit<uint16_t, 4>("123x", "123f", false, "defined: x can't be more than f");
+  doit<uint16_t, 4>("123x", "123e", true, "undefined: x can be more than e, error above");
+
+  doit<uint16_t, 5>("xxxx", "xxxx", true, "completely undefined, error above");
+  doit<uint16_t, 5>("0000", "0000", false, "completely defined");
+  doit<uint16_t, 5>("0000", "f000", false, "completely defined");
+  doit<uint16_t, 5>("f000", "0000", false, "completely defined");
+  doit<uint16_t, 5>("0000", "fxxx", false, "defined: 0 > all negatives");
+  doit<uint16_t, 5>("0xxx", "fxxx", false, "defined: non-negatives > all negatives");
+  doit<uint16_t, 5>("xxx0", "f000", true, "undefined, error above");
+  doit<uint16_t, 5>("xxx1", "8000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint16_t, 5>("5xxx", "6xxx", false, "defined");
+  doit<uint16_t, 5>("8xxx", "9xxx", false, "defined");
+  doit<uint16_t, 5>("123x", "1234", true, "undefined, error above");
+  doit<uint16_t, 5>("123x", "123f", false, "defined: x can't be more than f");
+  doit<uint16_t, 5>("123x", "123e", true, "undefined: x can be more than e, error above");
+
+  doit<uint16_t, 6>("xxxx", "xxxx", true, "completely undefined, error above");
+  doit<uint16_t, 6>("0000", "0000", false, "completely defined");
+  doit<uint16_t, 6>("0000", "f000", false, "completely defined");
+  doit<uint16_t, 6>("f000", "0000", false, "completely defined");
+  doit<uint16_t, 6>("0000", "fxxx", false, "defined: 0 > all negatives");
+  doit<uint16_t, 6>("0xxx", "fxxx", false, "defined: non-negatives > all negatives");
+  doit<uint16_t, 6>("xxx0", "f000", true, "undefined, error above");
+  doit<uint16_t, 6>("xxx1", "8000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint16_t, 6>("5xxx", "6xxx", false, "defined");
+  doit<uint16_t, 6>("8xxx", "9xxx", false, "defined");
+  doit<uint16_t, 6>("123x", "1234", true, "undefined, error above");
+  doit<uint16_t, 6>("123x", "123f", false, "defined: x can't be more than f");
+  doit<uint16_t, 6>("123x", "123e", true, "undefined: x can be more than e, error above");
+
+  doit<uint16_t, 7>("xxxx", "xxxx", true, "completely undefined, error above");
+  doit<uint16_t, 7>("0000", "0000", false, "completely defined");
+  doit<uint16_t, 7>("0000", "f000", false, "completely defined");
+  doit<uint16_t, 7>("f000", "0000", false, "completely defined");
+  doit<uint16_t, 7>("0000", "fxxx", false, "defined: 0 > all negatives");
+  doit<uint16_t, 7>("0xxx", "fxxx", false, "defined: non-negatives > all negatives");
+  doit<uint16_t, 7>("xxx0", "f000", true, "undefined, error above");
+  doit<uint16_t, 7>("xxx1", "8000", false, "defined: ends with 1 > MIN_INT");
+  doit<uint16_t, 7>("5xxx", "6xxx", false, "defined");
+  doit<uint16_t, 7>("8xxx", "9xxx", false, "defined");
+  doit<uint16_t, 7>("123x", "1234", true, "undefined, error above");
+  doit<uint16_t, 7>("123x", "123f", false, "defined: x can't be more than f");
+  doit<uint16_t, 7>("123x", "123e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 0>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 0>("00", "00", false, "completely defined");
+  doit<uint8_t, 0>("00", "f0", false, "completely defined");
+  doit<uint8_t, 0>("f0", "00", false, "completely defined");
+  doit<uint8_t, 0>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 0>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 0>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 0>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 0>("5x", "6x", false, "defined");
+  doit<uint8_t, 0>("8x", "9x", false, "defined");
+  doit<uint8_t, 0>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 0>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 0>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 1>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 1>("00", "00", false, "completely defined");
+  doit<uint8_t, 1>("00", "f0", false, "completely defined");
+  doit<uint8_t, 1>("f0", "00", false, "completely defined");
+  doit<uint8_t, 1>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 1>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 1>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 1>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 1>("5x", "6x", false, "defined");
+  doit<uint8_t, 1>("8x", "9x", false, "defined");
+  doit<uint8_t, 1>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 1>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 1>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 2>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 2>("00", "00", false, "completely defined");
+  doit<uint8_t, 2>("00", "f0", false, "completely defined");
+  doit<uint8_t, 2>("f0", "00", false, "completely defined");
+  doit<uint8_t, 2>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 2>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 2>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 2>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 2>("5x", "6x", false, "defined");
+  doit<uint8_t, 2>("8x", "9x", false, "defined");
+  doit<uint8_t, 2>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 2>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 2>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 3>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 3>("00", "00", false, "completely defined");
+  doit<uint8_t, 3>("00", "f0", false, "completely defined");
+  doit<uint8_t, 3>("f0", "00", false, "completely defined");
+  doit<uint8_t, 3>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 3>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 3>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 3>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 3>("5x", "6x", false, "defined");
+  doit<uint8_t, 3>("8x", "9x", false, "defined");
+  doit<uint8_t, 3>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 3>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 3>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 4>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 4>("00", "00", false, "completely defined");
+  doit<uint8_t, 4>("00", "f0", false, "completely defined");
+  doit<uint8_t, 4>("f0", "00", false, "completely defined");
+  doit<uint8_t, 4>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 4>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 4>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 4>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 4>("5x", "6x", false, "defined");
+  doit<uint8_t, 4>("8x", "9x", false, "defined");
+  doit<uint8_t, 4>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 4>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 4>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 5>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 5>("00", "00", false, "completely defined");
+  doit<uint8_t, 5>("00", "f0", false, "completely defined");
+  doit<uint8_t, 5>("f0", "00", false, "completely defined");
+  doit<uint8_t, 5>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 5>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 5>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 5>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 5>("5x", "6x", false, "defined");
+  doit<uint8_t, 5>("8x", "9x", false, "defined");
+  doit<uint8_t, 5>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 5>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 5>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 6>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 6>("00", "00", false, "completely defined");
+  doit<uint8_t, 6>("00", "f0", false, "completely defined");
+  doit<uint8_t, 6>("f0", "00", false, "completely defined");
+  doit<uint8_t, 6>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 6>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 6>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 6>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 6>("5x", "6x", false, "defined");
+  doit<uint8_t, 6>("8x", "9x", false, "defined");
+  doit<uint8_t, 6>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 6>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 6>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 7>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 7>("00", "00", false, "completely defined");
+  doit<uint8_t, 7>("00", "f0", false, "completely defined");
+  doit<uint8_t, 7>("f0", "00", false, "completely defined");
+  doit<uint8_t, 7>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 7>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 7>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 7>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 7>("5x", "6x", false, "defined");
+  doit<uint8_t, 7>("8x", "9x", false, "defined");
+  doit<uint8_t, 7>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 7>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 7>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 8>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 8>("00", "00", false, "completely defined");
+  doit<uint8_t, 8>("00", "f0", false, "completely defined");
+  doit<uint8_t, 8>("f0", "00", false, "completely defined");
+  doit<uint8_t, 8>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 8>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 8>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 8>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 8>("5x", "6x", false, "defined");
+  doit<uint8_t, 8>("8x", "9x", false, "defined");
+  doit<uint8_t, 8>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 8>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 8>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 9>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 9>("00", "00", false, "completely defined");
+  doit<uint8_t, 9>("00", "f0", false, "completely defined");
+  doit<uint8_t, 9>("f0", "00", false, "completely defined");
+  doit<uint8_t, 9>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 9>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 9>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 9>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 9>("5x", "6x", false, "defined");
+  doit<uint8_t, 9>("8x", "9x", false, "defined");
+  doit<uint8_t, 9>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 9>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 9>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 10>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 10>("00", "00", false, "completely defined");
+  doit<uint8_t, 10>("00", "f0", false, "completely defined");
+  doit<uint8_t, 10>("f0", "00", false, "completely defined");
+  doit<uint8_t, 10>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 10>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 10>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 10>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 10>("5x", "6x", false, "defined");
+  doit<uint8_t, 10>("8x", "9x", false, "defined");
+  doit<uint8_t, 10>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 10>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 10>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 11>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 11>("00", "00", false, "completely defined");
+  doit<uint8_t, 11>("00", "f0", false, "completely defined");
+  doit<uint8_t, 11>("f0", "00", false, "completely defined");
+  doit<uint8_t, 11>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 11>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 11>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 11>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 11>("5x", "6x", false, "defined");
+  doit<uint8_t, 11>("8x", "9x", false, "defined");
+  doit<uint8_t, 11>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 11>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 11>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 12>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 12>("00", "00", false, "completely defined");
+  doit<uint8_t, 12>("00", "f0", false, "completely defined");
+  doit<uint8_t, 12>("f0", "00", false, "completely defined");
+  doit<uint8_t, 12>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 12>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 12>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 12>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 12>("5x", "6x", false, "defined");
+  doit<uint8_t, 12>("8x", "9x", false, "defined");
+  doit<uint8_t, 12>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 12>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 12>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 13>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 13>("00", "00", false, "completely defined");
+  doit<uint8_t, 13>("00", "f0", false, "completely defined");
+  doit<uint8_t, 13>("f0", "00", false, "completely defined");
+  doit<uint8_t, 13>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 13>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 13>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 13>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 13>("5x", "6x", false, "defined");
+  doit<uint8_t, 13>("8x", "9x", false, "defined");
+  doit<uint8_t, 13>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 13>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 13>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 14>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 14>("00", "00", false, "completely defined");
+  doit<uint8_t, 14>("00", "f0", false, "completely defined");
+  doit<uint8_t, 14>("f0", "00", false, "completely defined");
+  doit<uint8_t, 14>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 14>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 14>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 14>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 14>("5x", "6x", false, "defined");
+  doit<uint8_t, 14>("8x", "9x", false, "defined");
+  doit<uint8_t, 14>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 14>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 14>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+  doit<uint8_t, 15>("xx", "xx", true, "completely undefined, error above");
+  doit<uint8_t, 15>("00", "00", false, "completely defined");
+  doit<uint8_t, 15>("00", "f0", false, "completely defined");
+  doit<uint8_t, 15>("f0", "00", false, "completely defined");
+  doit<uint8_t, 15>("00", "fx", false, "defined: 0 > all negatives");
+  doit<uint8_t, 15>("0x", "fx", false, "defined: non-negatives > all negatives");
+  doit<uint8_t, 15>("x0", "f0", true, "undefined, error above");
+  doit<uint8_t, 15>("x1", "80", false, "defined: ends with 1 > MIN_INT");
+  doit<uint8_t, 15>("5x", "6x", false, "defined");
+  doit<uint8_t, 15>("8x", "9x", false, "defined");
+  doit<uint8_t, 15>("1x", "12", true, "undefined, error above");
+  doit<uint8_t, 15>("1x", "1f", false, "defined: x can't be more than f");
+  doit<uint8_t, 15>("1x", "1e", true, "undefined: x can be more than e, error above");
+
+
+  return 0;
+}

--- a/memcheck/tests/x86/Makefile.am
+++ b/memcheck/tests/x86/Makefile.am
@@ -16,6 +16,7 @@ EXTRA_DIST = \
 	pushfpopf.stderr.exp pushfpopf.stdout.exp pushfpopf.vgtest \
 	pushfw_x86.vgtest pushfw_x86.stdout.exp pushfw_x86.stderr.exp \
 	pushpopmem.stderr.exp pushpopmem.stdout.exp pushpopmem.vgtest \
+	pcmpgt.stderr.exp pcmpgt.vgtest \
 	sh-mem-vec128-plo-no.vgtest \
 		sh-mem-vec128-plo-no.stderr.exp \
 		sh-mem-vec128-plo-no.stdout.exp \
@@ -40,6 +41,7 @@ check_PROGRAMS = \
 	pushfpopf \
 	pushfw_x86 \
 	pushpopmem \
+	pcmpgt \
 	sh-mem-vec128 \
 	sse_memory \
 	tronical \
@@ -62,3 +64,4 @@ endif
 tronical_SOURCES 	= tronical.S
 
 more_x86_fp_LDADD	= -lm
+pcmpgt_SOURCES = pcmpgt.cpp

--- a/memcheck/tests/x86/pcmpgt.cpp
+++ b/memcheck/tests/x86/pcmpgt.cpp
@@ -1,0 +1,1 @@
+../common/pcmpgt.cpp

--- a/memcheck/tests/x86/pcmpgt.stderr.exp
+++ b/memcheck/tests/x86/pcmpgt.stderr.exp
@@ -1,0 +1,1498 @@
+
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:191)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:191)
+
+xxxxxxxx > xxxxxxxx, completely undefined, error above, 1 == 1
+00000000 > 00000000, completely defined, 0 == 0
+00000000 > f0000000, completely defined, 0 == 0
+f0000000 > 00000000, completely defined, 0 == 0
+00000000 > fxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxx > fxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:197)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:197)
+
+xxxxxxx0 > f0000000, undefined, error above, 1 == 1
+xxxxxxx1 > 80000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxx > 6xxxxxxx, defined, 0 == 0
+8xxxxxxx > 9xxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:201)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:201)
+
+1234567x > 12345678, undefined, error above, 1 == 1
+1234567x > 1234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:203)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:203)
+
+1234567x > 1234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:205)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:205)
+
+xxxxxxxx > xxxxxxxx, completely undefined, error above, 1 == 1
+00000000 > 00000000, completely defined, 0 == 0
+00000000 > f0000000, completely defined, 0 == 0
+f0000000 > 00000000, completely defined, 0 == 0
+00000000 > fxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxx > fxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:211)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:211)
+
+xxxxxxx0 > f0000000, undefined, error above, 1 == 1
+xxxxxxx1 > 80000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxx > 6xxxxxxx, defined, 0 == 0
+8xxxxxxx > 9xxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:215)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:215)
+
+1234567x > 12345678, undefined, error above, 1 == 1
+1234567x > 1234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:217)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:217)
+
+1234567x > 1234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:219)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:219)
+
+xxxxxxxx > xxxxxxxx, completely undefined, error above, 1 == 1
+00000000 > 00000000, completely defined, 0 == 0
+00000000 > f0000000, completely defined, 0 == 0
+f0000000 > 00000000, completely defined, 0 == 0
+00000000 > fxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxx > fxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:225)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:225)
+
+xxxxxxx0 > f0000000, undefined, error above, 1 == 1
+xxxxxxx1 > 80000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxx > 6xxxxxxx, defined, 0 == 0
+8xxxxxxx > 9xxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:229)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:229)
+
+1234567x > 12345678, undefined, error above, 1 == 1
+1234567x > 1234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:231)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:231)
+
+1234567x > 1234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:233)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:233)
+
+xxxxxxxx > xxxxxxxx, completely undefined, error above, 1 == 1
+00000000 > 00000000, completely defined, 0 == 0
+00000000 > f0000000, completely defined, 0 == 0
+f0000000 > 00000000, completely defined, 0 == 0
+00000000 > fxxxxxxx, defined: 0 > all negatives, 0 == 0
+0xxxxxxx > fxxxxxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:239)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:239)
+
+xxxxxxx0 > f0000000, undefined, error above, 1 == 1
+xxxxxxx1 > 80000000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxxxxxx > 6xxxxxxx, defined, 0 == 0
+8xxxxxxx > 9xxxxxxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:243)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:243)
+
+1234567x > 12345678, undefined, error above, 1 == 1
+1234567x > 1234567f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:245)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned int, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:245)
+
+1234567x > 1234567e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:247)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:247)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:253)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:253)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:257)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:257)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:259)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:259)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:261)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:261)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:267)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:267)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:271)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:271)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:273)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:273)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:275)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:275)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:281)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:281)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:285)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:285)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:287)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:287)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:289)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:289)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:295)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:295)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:299)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:299)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:301)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:301)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:303)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:303)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:309)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:309)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:313)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:313)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:315)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:315)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:317)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:317)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:323)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:323)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:327)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:327)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:329)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:329)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:331)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:331)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:337)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:337)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:341)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:341)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:343)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:343)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:345)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:345)
+
+xxxx > xxxx, completely undefined, error above, 1 == 1
+0000 > 0000, completely defined, 0 == 0
+0000 > f000, completely defined, 0 == 0
+f000 > 0000, completely defined, 0 == 0
+0000 > fxxx, defined: 0 > all negatives, 0 == 0
+0xxx > fxxx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:351)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:351)
+
+xxx0 > f000, undefined, error above, 1 == 1
+xxx1 > 8000, defined: ends with 1 > MIN_INT, 0 == 0
+5xxx > 6xxx, defined, 0 == 0
+8xxx > 9xxx, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:355)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:355)
+
+123x > 1234, undefined, error above, 1 == 1
+123x > 123f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:357)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned short, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:357)
+
+123x > 123e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:359)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:359)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:365)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:365)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+
+More than 100 errors detected.  Subsequent errors
+will still be recorded, but in less detail than before.
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:369)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:369)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:371)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 0>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:371)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:373)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:373)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:379)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:379)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:383)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:383)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:385)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 1>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:385)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:387)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:387)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:393)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:393)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:397)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:397)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:399)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 2>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:399)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:401)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:401)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:407)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:407)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:411)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:411)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:413)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 3>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:413)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:415)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:415)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:421)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:421)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:425)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:425)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:427)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 4>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:427)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:429)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:429)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:435)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:435)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:439)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:439)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:441)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 5>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:441)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:443)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:443)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:449)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:449)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:453)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:453)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:455)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 6>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:455)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:457)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:457)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:463)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:463)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:467)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:467)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:469)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 7>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:469)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:471)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:471)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:477)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:477)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:481)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:481)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:483)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 8>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:483)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:485)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:485)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:491)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:491)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:495)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:495)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:497)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 9>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:497)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:499)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:499)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:505)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:505)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:509)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:509)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:511)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 10>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:511)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:513)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:513)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:519)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:519)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:523)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:523)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:525)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 11>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:525)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:527)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:527)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:533)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:533)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:537)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:537)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:539)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 12>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:539)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:541)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:541)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:547)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:547)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:551)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:551)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:553)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 13>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:553)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:555)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:555)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:561)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:561)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:565)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:565)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:567)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 14>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:567)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:569)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:569)
+
+xx > xx, completely undefined, error above, 1 == 1
+00 > 00, completely defined, 0 == 0
+00 > f0, completely defined, 0 == 0
+f0 > 00, completely defined, 0 == 0
+00 > fx, defined: 0 > all negatives, 0 == 0
+0x > fx, defined: non-negatives > all negatives, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:575)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:575)
+
+x0 > f0, undefined, error above, 1 == 1
+x1 > 80, defined: ends with 1 > MIN_INT, 0 == 0
+5x > 6x, defined, 0 == 0
+8x > 9x, defined, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:579)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:579)
+
+1x > 12, undefined, error above, 1 == 1
+1x > 1f, defined: x can't be more than f, 0 == 0
+Uninitialised byte(s) found during client check request
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:179)
+   by 0x........: main (pcmpgt.cpp:581)
+ Address 0x........ is on thread 1's stack
+ in frame #0, created by void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:175)
+
+Conditional jump or move depends on uninitialised value(s)
+   at 0x........: void doit<unsigned char, 15>(char const*, char const*, bool, char const*) (pcmpgt.cpp:184)
+   by 0x........: main (pcmpgt.cpp:581)
+
+1x > 1e, undefined: x can be more than e, error above, 1 == 1
+
+HEAP SUMMARY:
+    in use at exit: ... bytes in ... blocks
+  total heap usage: ... allocs, ... frees, ... bytes allocated
+
+For a detailed leak analysis, rerun with: --leak-check=full
+
+Use --track-origins=yes to see where uninitialised values come from
+For lists of detected and suppressed errors, rerun with: -s
+ERROR SUMMARY: 224 errors from 224 contexts (suppressed: 0 from 0)

--- a/memcheck/tests/x86/pcmpgt.vgtest
+++ b/memcheck/tests/x86/pcmpgt.vgtest
@@ -1,0 +1,3 @@
+prog: pcmpgt x86
+prereq: test -e pcmpgt
+stderr_filter: ../filter_allocs


### PR DESCRIPTION
This adds support for 64bit, 16bit, and 8bit to the existing 32bit support.

To test:

```sh
./autogen.sh
./configure
make -j 20
make -j 20 check
perl tests/vg_regtest memcheck/tests/amd64/pcmpgt
perl tests/vg_regtest memcheck/tests/x86/pcmpgt
```

This fixes https://bugs.kde.org/show_bug.cgi?id=432801