### PR TITLE
Only quit on the first error if that error is "counted".

### DIFF
--- a/coregrind/m_errormgr.c
+++ b/coregrind/m_errormgr.c
@@ -518,7 +518,7 @@ Bool VG_(is_action_requested) ( const HChar* action, Bool* clo )
    * possibly, generate a suppression.
 */
 static 
-void do_actions_on_error(const Error* err, Bool allow_db_attach)
+void do_actions_on_error(const Error* err, Bool allow_db_attach, Bool count_error)
 {
    Bool still_noisy = True;
 
@@ -543,7 +543,7 @@ void do_actions_on_error(const Error* err, Bool allow_db_attach)
    if (VG_(clo_gen_suppressions) == 1 && !still_noisy)
       VG_(clo_gen_suppressions) = 0;
 
-   if (VG_(clo_exit_on_first_error)) {
+   if (count_error && VG_(clo_exit_on_first_error)) {
       if (VG_(clo_xml))
          VG_(printf_xml)("</valgrindoutput>\n");
       VG_(umsg)("\n");
@@ -581,7 +581,7 @@ void do_actions_on_error(const Error* err, Bool allow_db_attach)
    * calls do_actions_on_error.  This optionally does a gdbserver call
      and optionally prints a suppression; both of these may require user input.
 */
-static void pp_Error ( const Error* err, Bool allow_db_attach, Bool xml )
+static void pp_Error ( const Error* err, Bool allow_db_attach, Bool xml, Bool count_error )
 {
    /* If this fails, you probably specified your tool's method
       dictionary incorrectly. */
@@ -642,7 +642,7 @@ static void pp_Error ( const Error* err, Bool allow_db_attach, Bool xml )
 
    }
 
-   do_actions_on_error(err, allow_db_attach);
+   do_actions_on_error(err, allow_db_attach, count_error);
 }
 
 
@@ -849,7 +849,7 @@ void VG_(maybe_record_error) ( ThreadId tid,
       n_errs_found++;
       n_errs_shown++;
       /* Actually show the error; more complex than you might think. */
-      pp_Error( p, /*allow_db_attach*/True, VG_(clo_xml) );
+      pp_Error( p, /*allow_db_attach*/True, VG_(clo_xml), /* count_error */ True );
    } else {
       n_supp_contexts++;
       n_errs_suppressed++;
@@ -899,7 +899,7 @@ Bool VG_(unique_error) ( ThreadId tid, ErrorKind ekind, Addr a, const HChar* s,
          /* update stats */
          n_errs_shown++;
          /* Actually show the error; more complex than you might think. */
-         pp_Error(&err, allow_db_attach, VG_(clo_xml));
+         pp_Error(&err, allow_db_attach, VG_(clo_xml), count_error);
       }
       return False;
 
@@ -1025,7 +1025,7 @@ void VG_(show_all_errors) (  Int verbosity, Bool xml )
       VG_(umsg)("\n");
       VG_(umsg)("%d errors in context %d of %u:\n",
                 p_min->count, i+1, n_err_contexts);
-      pp_Error( p_min, False/*allow_db_attach*/, False /* xml */ );
+      pp_Error( p_min, False/*allow_db_attach*/, False /* xml */, True /* count_error */ );
 
       // We're not printing XML -- we'd have exited above if so.
       vg_assert(! xml);
@@ -1068,7 +1068,7 @@ void VG_(show_last_error) ( void )
       return;
    }
 
-   pp_Error( errors, False/*allow_db_attach*/, False/*xml*/ );
+   pp_Error( errors, False/*allow_db_attach*/, False/*xml*/, True/*count_error*/ );
 }
 
 

--- a/memcheck/tests/Makefile.am
+++ b/memcheck/tests/Makefile.am
@@ -212,6 +212,7 @@ EXTRA_DIST = \
 	inltemplate.stderr.exp inltemplate.stdout.exp inltemplate.vgtest \
 		inltemplate.stderr.exp-old-gcc \
 	leak-0.vgtest leak-0.stderr.exp \
+	leak-cases-exit-on-definite.vgtest leak-cases-exit-on-definite.stderr.exp \
 	leak-cases-full.vgtest leak-cases-full.stderr.exp \
 	leak-cases-possible.vgtest leak-cases-possible.stderr.exp \
 	leak-cases-summary.vgtest leak-cases-summary.stderr.exp \

--- a/memcheck/tests/leak-cases-exit-on-definite.stderr.exp
+++ b/memcheck/tests/leak-cases-exit-on-definite.stderr.exp
@@ -1,0 +1,64 @@
+
+All heap blocks were freed -- no leaks are possible
+
+LEAK SUMMARY:
+   definitely lost: 48 bytes in 3 blocks
+   indirectly lost: 32 bytes in 2 blocks
+     possibly lost: 96 bytes in 6 blocks
+   still reachable: 64 bytes in 4 blocks
+        suppressed: 0 bytes in 0 blocks
+Rerun with --leak-check=full to see details of leaked memory
+
+leaked:      80 bytes in  5 blocks
+dubious:     96 bytes in  6 blocks
+reachable:   64 bytes in  4 blocks
+suppressed:   0 bytes in  0 blocks
+
+HEAP SUMMARY:
+    in use at exit: 240 bytes in 15 blocks
+  total heap usage: 15 allocs, 0 frees, 240 bytes allocated
+
+16 bytes in 1 blocks are possibly lost in loss record ... of ...
+   at 0x........: malloc (vg_replace_malloc.c:...)
+   by 0x........: mk (leak-cases.c:52)
+   by 0x........: f (leak-cases.c:78)
+   by 0x........: main (leak-cases.c:107)
+
+16 bytes in 1 blocks are possibly lost in loss record ... of ...
+   at 0x........: malloc (vg_replace_malloc.c:...)
+   by 0x........: mk (leak-cases.c:52)
+   by 0x........: f (leak-cases.c:81)
+   by 0x........: main (leak-cases.c:107)
+
+16 bytes in 1 blocks are possibly lost in loss record ... of ...
+   at 0x........: malloc (vg_replace_malloc.c:...)
+   by 0x........: mk (leak-cases.c:52)
+   by 0x........: f (leak-cases.c:84)
+   by 0x........: main (leak-cases.c:107)
+
+16 bytes in 1 blocks are possibly lost in loss record ... of ...
+   at 0x........: malloc (vg_replace_malloc.c:...)
+   by 0x........: mk (leak-cases.c:52)
+   by 0x........: f (leak-cases.c:84)
+   by 0x........: main (leak-cases.c:107)
+
+16 bytes in 1 blocks are possibly lost in loss record ... of ...
+   at 0x........: malloc (vg_replace_malloc.c:...)
+   by 0x........: mk (leak-cases.c:52)
+   by 0x........: f (leak-cases.c:87)
+   by 0x........: main (leak-cases.c:107)
+
+16 bytes in 1 blocks are possibly lost in loss record ... of ...
+   at 0x........: malloc (vg_replace_malloc.c:...)
+   by 0x........: mk (leak-cases.c:52)
+   by 0x........: f (leak-cases.c:87)
+   by 0x........: main (leak-cases.c:107)
+
+16 bytes in 1 blocks are definitely lost in loss record ... of ...
+   at 0x........: malloc (vg_replace_malloc.c:...)
+   by 0x........: mk (leak-cases.c:52)
+   by 0x........: f (leak-cases.c:74)
+   by 0x........: main (leak-cases.c:107)
+
+
+Exit program on first error (--exit-on-first-error=yes)

--- a/memcheck/tests/leak-cases-exit-on-definite.vgtest
+++ b/memcheck/tests/leak-cases-exit-on-definite.vgtest
@@ -1,0 +1,3 @@
+prog: leak-cases
+vgopts: --error-exitcode=127 --errors-for-leak-kinds=definite --leak-check=full -s --exit-on-first-error=yes
+stderr_filter_args: leak-cases.c


### PR DESCRIPTION
It's possible for the user to specify in the memcheck that some errors should not cause an exit with the error-exitcode value.  For those errors which would not cause an error exitcode, do not count them for the purposes of exiting after the first error.